### PR TITLE
Do not rely on options variable in essence editor files

### DIFF
--- a/app/views/alchemy/essences/_essence_audio_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_audio_editor.html.erb
@@ -1,6 +1,6 @@
 <%= render(
   'alchemy/essences/richmedia_essence_editor',
-  options: options,
+  options: local_assigns.fetch(:options, {}),
   content: content,
   controller: 'essence_audios'
 ) %>

--- a/app/views/alchemy/essences/_essence_video_editor.html.erb
+++ b/app/views/alchemy/essences/_essence_video_editor.html.erb
@@ -1,6 +1,6 @@
 <%= render(
   'alchemy/essences/richmedia_essence_editor',
-  options: options,
+  options: local_assigns.fetch(:options, {}),
   content: content,
   controller: 'essence_videos'
 ) %>


### PR DESCRIPTION
Alchemy 4.4 deprecated the use of element editors and does not pass around local options anymore.