### PR TITLE
Remove essence_file assign override

### DIFF
--- a/app/views/alchemy/admin/essence_files/assign.js.erb
+++ b/app/views/alchemy/admin/essence_files/assign.js.erb
@@ -1,9 +1,0 @@
-$('#<%= @content.dom_id %>').replaceWith('<%= j(
-  render "alchemy/essences/#{@content.essence_partial_name}_editor",
-    formats: [:html],
-    content: @content,
-    options: @options
-) %>');
-Alchemy.closeCurrentDialog();
-Alchemy.setElementDirty($('#element_<%= @content.element.id %>'));
-Alchemy.watchForDialogs($('#<%= @content.dom_id %>'));


### PR DESCRIPTION
This somehow got overridden a few years back for unkown reasons. It currently breaks assigning files and works just fine without.