### PR TITLE
Deprecate for Alchemy v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ Adds HTML5 `EssenceAudio` and `EssenceVideo` essences to your AlchemyCMS powered
 
 ## Alchemy version
 
-This version is compatible with Alchemy v4.0 and above only.
+**This gem has been merged into Alchemy v6.**
+
+You can safely remove it from your Gemfile after upgrading to Alchemy v6.
+
+This version is compatible with Alchemy v4 and v5 only.
 
 - For Alchemy v3.x please use version 1.0.0.
 - For Alchemy v2.7.0 please use version 0.2.0.

--- a/alchemy-richmedia-essences.gemspec
+++ b/alchemy-richmedia-essences.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.version       = Alchemy::Richmedia::Essences::VERSION
   gem.authors       = ["Thomas von Deyen"]
   gem.email         = ["thomas@vondeyen.com"]
-  gem.description   = %q{EssenceAudio and EssenceVideo for AlchemyCMS 4.0}
+  gem.description   = %q{EssenceAudio and EssenceVideo for AlchemyCMS 4 and 5}
   gem.summary       = %q{Adds EssenceAudio and EssenceVideo essences to your AlchemyCMS powered website.}
   gem.homepage      = "http://alchemy-cms.com"
   gem.license       = 'BSD New'
@@ -16,5 +16,5 @@ Gem::Specification.new do |gem|
   gem.files         = `git ls-files`.split($/)
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency 'alchemy_cms', ['>= 4.0.0.rc1']
+  gem.add_runtime_dependency 'alchemy_cms', ['>= 4.0.0.rc1', '< 6.0.0.alpha']
 end


### PR DESCRIPTION
This gem [has been merged into Alchemy v6](https://github.com/AlchemyCMS/alchemy_cms/pull/2089) and is not necessary anymore.